### PR TITLE
Add basic framerate control and fix minor compilation issues

### DIFF
--- a/source/Constants.hpp
+++ b/source/Constants.hpp
@@ -35,4 +35,14 @@
  */
 #define ROM_FILENAME "Super Mario Bros. (JU) (PRG0) [!].nes"
 
+/**
+ * Desired frames per second
+ */
+#define FPS 60
+
+/**
+ * MilliSeconds per second
+ */
+#define MS_PER_SEC 1000
+
 #endif // CONSTANTS_HPP

--- a/source/Main.cpp
+++ b/source/Main.cpp
@@ -125,6 +125,8 @@ static void mainLoop()
     engine.reset();
 
     bool running = true;
+    int progStartTime = SDL_GetTicks();
+    int frame = 0;
     while (running)
     {
         SDL_Event event;
@@ -192,6 +194,23 @@ static void mainLoop()
         SDL_RenderCopy(renderer, scanlineTexture, NULL, NULL);
 
         SDL_RenderPresent(renderer);
+
+        /**
+         * Ensure that the framerate stays as close to 60FPS as possible. If the frame was rendered faster, then delay. 
+         * If the frame was slower, reset time so that the game doesn't try to "catch up", going super-speed.
+         */
+        int now = SDL_GetTicks();
+        int delay = progStartTime + int(double(frame) * double(MS_PER_SEC) / double(FPS)) - now;
+        if(delay > 0) 
+        {
+            SDL_Delay(delay);
+        }
+        else 
+        {
+            frame = 0;
+            progStartTime = now;
+        }
+        frame++;
     }
 }
 

--- a/source/SMB/SMBEngine.cpp
+++ b/source/SMB/SMBEngine.cpp
@@ -223,5 +223,5 @@ void SMBEngine::writeData(uint16_t address, const uint8_t* data, size_t length)
 {
     address -= DATA_STORAGE_OFFSET;
 
-    memcpy(dataStorage + (ptrdiff_t)address, data, length);
+    memcpy(dataStorage + (std::ptrdiff_t)address, data, length);
 }

--- a/source/SMB/SMBEngine.hpp
+++ b/source/SMB/SMBEngine.hpp
@@ -166,7 +166,7 @@ private:
     /**
      * Map constant data to the address space. The address must be at least 0x8000.
      */
-    void writeData(uint16_t address, const uint8_t* data, size_t length);
+    void writeData(uint16_t address, const uint8_t* data, std::size_t length);
 };
 
 #endif // SMBENGINE_HPP


### PR DESCRIPTION
- If a frame comes out faster than 60FPS, delay to limit the framerate

- If a frame comes out late, reset time and frame count (otherwise, the game speeds up unreasonably to try to make up for lost time)

- I haven't verified, but I'm assuming that the difference between my environment and yours may have something to do with vsync (disabled on mine, enabled on yours).

- Added "std::" namespace designations to some variables in the game
  engine