### PR TITLE
Add target_link_libraries(smbc SDL2) for Manjaro

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,3 +27,4 @@ add_executable(smbc ${SOURCE_FILES})
 target_link_libraries(smbc ${SDL2_LIBRARY} ${SDL2_LIBRARIES})
 
 add_dependencies(smbc codegen)
+target_link_libraries(smbc SDL2)


### PR DESCRIPTION
Add target_link_libraries(smbc SDL2) for Manjaro Linux .