### PR TITLE
Fix bug in MemoryAccess.cpp

### DIFF
--- a/source/Emulation/MemoryAccess.cpp
+++ b/source/Emulation/MemoryAccess.cpp
@@ -12,7 +12,7 @@ MemoryAccess::MemoryAccess(SMBEngine& engine, uint8_t constant) :
     engine(engine)
 {
     this->constant = constant;
-    this->value = &constant;
+    this->value = &this->constant;
 }
 
 MemoryAccess& MemoryAccess::operator = (uint8_t value)


### PR DESCRIPTION
Detected a bug, where the reference is taken from the argument-by-value and not the persistent class member. The bug would manifest when compiling with -O3 (yet work correctly with -O0). I recommend this fix to prevent others from experimenting this problem.